### PR TITLE
Edits for the remainder of the Python tutorial notebook

### DIFF
--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -546,35 +546,95 @@
    "source": [
     "## Example for IC-based measures\n",
     "\n",
-    "Information-content-based measures augment the structural distances, captured by the taxonomy with word frequencies. Thus the problem of lacking uniform distances in the Graph can be reduced by providing additional information about the typicality of words. The frequencies are used to compute the information content, which graduates concepts from specific to general. If a very specific synset is compared to a very general one, the relatedness will be low. The relatedness is measured based on the information content of the lowest common subsumer (the lowest synset in the hierachy that is hypernym to both synsets that are compared to each other).\n",
+    "One problem with path-based measures is that paths of the same length in the hypernym relation can correspond to very different intuitive semantic \"distances\".\n",
+    "Measures based on *information content* (IC) seek to solve this problem by augmenting information about the structural distances in the hypernym relation with information about word frequencies. \n",
+    "The word frequencies are used to compute the information content, which grades concepts from more specific to more general. If a very specific synset is compared to a very general one, the relatedness will be low. The relatedness of two synsets measured based on the information content of their least common subsumer (the lowest synset in the hierarchy that is hypernym to both synsets).\n",
     "\n",
-    "To use these measures, you have to create an object that takes frequency lists as an additional argument. These lists contain the raw frequencies of the nouns, adjectives and verbs that are in Germanet, based on a very large corpus. You can eihter use the provided frequency lists or use your own lists.\n",
-    "\n",
-    "The following code snippet shows the advantage of the IC-based measures. While path-based measures would classify the word pair Pflanze 'plant', Tier 'animal' as bein almost as similar as the word pair Roteiche 'red oak' and Steineiche 'holm oak', the IC-based measures distinguish whether two synsets are very general or more specific and consequently assign a higher similarity score to the second word pair."
+    "To use these measures, you have to create an `ICBasedSimilarity` object that takes frequency lists as an additional argument. These lists contain the raw frequencies of the nouns, adjectives and verbs that are in Germanet, based on a very large corpus. You can use either the provided frequency lists or your own lists."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {}
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from germanetpy.icbased_similarity import ICBasedSimilarity\n",
-    "relatedness_nouns = ICBasedSimilarity(germanet=germanet, wordcategory=WordCategory.nomen,\n",
-    "                                          path=frequencylist_nouns)\n",
+    "relatedness_nouns = ICBasedSimilarity(germanet=germanet, \n",
+    "                                      wordcategory=WordCategory.nomen,\n",
+    "                                      path=frequencylist_nouns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following code snippet shows the advantage of the IC-based measures. While path-based measures would classify the words *Pflanze* 'plant' and *Tier* 'animal' as being almost as similar as the words *Roteiche* 'red oak' and *Steineiche* 'holm oak', the IC-based measures distinguish whether two synsets are very general or more specific and consequently assign a higher similarity score to the second pair of words."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# first word pair:\n",
     "pflanze = germanet.get_synset_by_id(\"s44960\")\n",
     "tier = germanet.get_synset_by_id(\"s48805\")\n",
-    "sim_leacock_pflanze_tier = relatedness_calculator.leacock_chodorow(pflanze, tier, normalize=True)\n",
-    "roteiche = germanet.get_synset_by_id(\"s46054\")\n",
-    "steineiche = germanet.get_synset_by_id(\"s46056\")\n",
-    "sim_leacock_roteiche_steineiche = relatedness_calculator.leacock_chodorow(roteiche, steineiche, normalize=True)\n",
-    "print(\"path-based similarity between Pflanze and Tier: %.2f, between Roteiche and Steineiche %.2f\"% (sim_leacock_pflanze_tier, sim_leacock_roteiche_steineiche))\n",
     "\n",
-    "sim_resnik_pflanze_tier = relatedness_nouns.resnik(pflanze, tier, normalize=True)\n",
-    "sim_resnik_roteiche_steineiche = relatedness_nouns.resnik(roteiche, steineiche, normalize=True)\n",
-    "print(\"ic-based similarity between Pflanze and Tier: %.2f, between Roteiche and Steineiche %.2f\" % (sim_resnik_pflanze_tier, sim_resnik_roteiche_steineiche))"
+    "# second word pair:\n",
+    "roteiche = germanet.get_synset_by_id(\"s46054\")\n",
+    "steineiche = germanet.get_synset_by_id(\"s46056\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that a path-based measure between these word pairs yields almost the same results:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relatedness_calculator.leacock_chodorow(pflanze, tier, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relatedness_calculator.leacock_chodorow(roteiche, steineiche, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But an IC-based measure clearly distinguishes the two pairs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relatedness_nouns.resnik(pflanze, tier, normalize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "relatedness_nouns.resnik(roteiche, steineiche, normalize=True)"
    ]
   },
   {

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -47,10 +47,7 @@
    "outputs": [],
    "source": [
     "from pathlib import Path\n",
-    "from germanetpy.germanet import Germanet\n",
-    "from germanetpy.frames import Frames\n",
-    "from germanetpy.filterconfig import Filterconfig\n",
-    "from germanetpy.synset import WordCategory, WordClass"
+    "from germanetpy.germanet import Germanet"
    ]
   },
   {
@@ -446,6 +443,7 @@
    "outputs": [],
    "source": [
     "from germanetpy.path_based_relatedness_measures import PathBasedRelatedness\n",
+    "from germanetpy.synset import WordCategory\n",
     "\n",
     "# First, construct a path-based similarity object. \n",
     "# The johannis_wurm and leber_trans synsets are maximally far apart among nouns:\n",
@@ -921,6 +919,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from germanetpy.frames import Frames\n",
+    "\n",
     "f = Frames(germanet.frames2lexunits)\n",
     "all_verbs_with_accusative_complement = f.extract_accusative_complement()"
    ]
@@ -979,6 +979,8 @@
    },
    "outputs": [],
    "source": [
+    "from germanetpy.filterconfig import Filterconfig\n",
+    "\n",
     "filterconfig = Filterconfig(\"schießen\", ignore_case=True)\n",
     "filterconfig.filter_synsets(germanet)"
    ]
@@ -996,6 +998,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from germanetpy.synset import WordClass\n",
+    "\n",
     "filterconfig.word_classes = [WordClass.Konkurrenz]\n",
     "filtered_result = filterconfig.filter_synsets(germanet)\n",
     "[(synset, synset.word_class) for synset in filtered_result]"

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -954,11 +954,16 @@
    },
    "source": [
     "## How to extract a large number of examples by applying a filter function\n",
-    "If you would like to extract several lexical units or synsets from GermaNet that fulfill a certain number of \n",
-    "conditions you can create a filter configuration. A filter configuration allows you for example to search for words of specific\n",
-    "Word Classes (e.g. you might be interested in extracting all abstract nouns) or you would like to extract all words that \n",
-    "contain a specific subword. To do a search you have to create a filter configuration object. You have to pass a search string\n",
-    "as an argument. All other options have defaults but you can set them to adapt your search. \n"
+    "If you would like to extract several lexical units or synsets from GermaNet that fulfill certain conditions you can create a filter configuration. For example, filter configurations allow you to search for words of specific\n",
+    "Word Classes (e.g. you might be interested in extracting all abstract nouns) or to extract all words that \n",
+    "contain a specific subword. To perform a search you have to create a filter configuration object. You have to pass a search string as an argument. All other options have defaults but you can override these defaults to refine your search.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For example, we can search for \"schießen\" but ignore upper or lowercasing in different orthforms:"
    ]
   },
   {
@@ -973,23 +978,44 @@
    },
    "outputs": [],
    "source": [
-    "# we can search for \"schuss\" but we don't want to care about upper or lowercasing and about different orthforms:\n",
     "filterconfig = Filterconfig(\"schießen\", ignore_case=True)\n",
-    "result = filterconfig.filter_synsets(germanet)\n",
-    "print(\"filtered result\")\n",
-    "for word in result:\n",
-    "    print(word)\n",
-    "# Let's say we are only interested in synsets of a specific semantic class:\n",
+    "filterconfig.filter_synsets(germanet)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's now limit the results to synsets of a specific semantic class:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "filterconfig.word_classes = [WordClass.Konkurrenz]\n",
-    "result = filterconfig.filter_synsets(germanet)\n",
-    "print(\"\\nfiltered result\")\n",
-    "for word in result:\n",
-    "    print(word, word.word_class)\n",
-    "# if we now filter by word category and use only nouns, our result will be empty because there is not entry for 'schießen' as a noun:\n",
+    "filtered_result = filterconfig.filter_synsets(germanet)\n",
+    "[(synset, synset.word_class) for synset in filtered_result]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we now filter by word category and use only nouns, our result will be empty because there is not entry for 'schießen' as a noun:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "filterconfig.word_categories = [WordCategory.nomen]\n",
     "result = filterconfig.filter_synsets(germanet)\n",
-    "print(\"\\nfiltered result\")\n",
-    "print(result)"
+    "result"
    ]
   },
   {
@@ -1002,9 +1028,7 @@
    },
    "source": [
     "Besides using full words as search strings we can use regular expressions. This can be very useful if you are interested \n",
-    "in words with certain character sequences. The next examples shows how to extract all words that end with \"kuchen\", all \n",
-    "words that contain a whitespace or hyphen (useful for example to extract multiword expressions) and how to extract verbs that contain\n",
-    "'ff' or 'ss':"
+    "in words with certain character sequences. The next example shows how to extract all words that end with \"kuchen\":"
    ]
   },
   {
@@ -1019,26 +1043,52 @@
    },
    "outputs": [],
    "source": [
-    "# extract all words that end with 'kuchen'\n",
     "filterconfig = Filterconfig('.*kuchen', regex=True)\n",
-    "filterconfig.word_categories = [WordCategory.nomen]\n",
     "result = filterconfig.filter_lexunits(germanet)\n",
     "print(\"Found  %d words that end with 'kuchen' in GermaNet \\n An example of such is: %s \\n Another example is : %s\"\n",
-    "      % (len(result), result.pop(), result.pop()))\n",
-    "\n",
-    "# extract all words that contain a white space or a hyphen\n",
+    "      % (len(result), result.pop(), result.pop()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This example extracts all nouns that contain whitespace or a hyphen (useful for example to extract multiword expressions):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# extract all nouns that contain whitespace or a hyphen\n",
     "filterconfig = Filterconfig('.+(\\s|-).+', regex=True)\n",
     "filterconfig.word_categories = [WordCategory.nomen]\n",
     "result = filterconfig.filter_lexunits(germanet)\n",
-    "print(\"\\nFound  %d multiword expressions with whitespace or hypen in GermaNet \\n An example of such is: %s \\n Another example is : %s\"\n",
-    "      % (len(result), result.pop(), result.pop()))\n",
-    "\n",
+    "print(\"\\nFound  %d multiword expressions with whitespace or hypen in GermaNet \\n An example of such is: %s \\n Another example is: %s\"\n",
+    "      % (len(result), result.pop(), result.pop()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And this example extracts verbs that contain 'ff' or 'ss':   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# extract all verbs that contain exactly two 'ss' or two 'ff'\n",
     "filterconfig = Filterconfig('.+(f{2,}|s{2,}).+', regex=True)\n",
     "filterconfig.word_categories = [WordCategory.verben]\n",
     "result = filterconfig.filter_lexunits(germanet)\n",
     "print(\"\\nFound  %d verbs with double s or double f in GermaNet \\n An example of such is: %s \\n Another example is : %s\"\n",
-    "      % (len(result), result.pop(), result.pop()))\n"
+    "      % (len(result), result.pop(), result.pop()))"
    ]
   }
  ],

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -35,22 +35,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "is_executing": false,
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from pathlib import Path\n",
-    "from germanetpy.germanet import Germanet"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "pycharm": {}
@@ -71,6 +55,9 @@
    "source": [
     "data_path = str(Path.home()) + \"/germanet_data\"\n",
     "frequencylist_nouns = data_path + \"/noun_freqs_decow14_16.txt\"\n",
+    "from pathlib import Path\n",
+    "from germanetpy.germanet import Germanet\n",
+    "\n",
     "germanet = Germanet(data_path)"
    ]
   },

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -427,12 +427,11 @@
    "source": [
     "## Example for path-based measures\n",
     "\n",
-    "The following example shows, how to use the PathBasedRelatedness to check whether Trompete (trumpet) is more related to \n",
-    "Posaune (trombone) than to Flöte (flute) and how to disambiguate Flügel (wing, blade, grand) in the context of Klavier (piano). \n",
+    "The following example shows how to use path-based semantic relatedness measures to check whether *Trompete* (trumpet) is more closely related to *Posaune* (trombone) than to *Flöte* (flute) and how to disambiguate *Flügel* (wing, blade, grand) in the context of *Klavier* (piano). \n",
     "\n",
-    "To use the path-based semantic relatedness measures you have to create the corresponding object. This object takes the longest possible shortest distance and a Synset pair that is maximally appart as argument. If not given, those will be computed on the fly but this might take somet time, especially for nouns.\n",
+    "To use the path-based semantic relatedness measures you have to initialize a `PathBasedRelatedness` object. This object takes the longest possible shortest distance and a Synset pair that is maximally apart as argument. If not given, this synset pair will be computed on the fly, but the computation might take some time, especially for nouns.\n",
     "\n",
-    "As mentioned before, those measures only work for synsets that belong to the same word category, which has to be specified in the constructor."
+    "As mentioned above, these measures only work for synsets that belong to the same word category, which has to be specified in the constructor."
    ]
   },
   {
@@ -447,38 +446,96 @@
    },
    "outputs": [],
    "source": [
-    "# first, construct a path-based similarity object\n",
     "from germanetpy.path_based_relatedness_measures import PathBasedRelatedness\n",
+    "\n",
+    "# First, construct a path-based similarity object. \n",
+    "# The johannis_wurm and leber_trans synsets are maximally far apart among nouns:\n",
     "johannis_wurm = germanet.get_synset_by_id(\"s49774\")\n",
     "leber_trans = germanet.get_synset_by_id(\"s83979\")\n",
     "relatedness_calculator = PathBasedRelatedness(germanet=germanet, category=WordCategory.nomen, max_len=35,\n",
-    "                                             max_depth=20, synset_pair=(johannis_wurm, leber_trans))\n",
+    "                                              max_depth=20, synset_pair=(johannis_wurm, leber_trans))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now use the `relatedness_calculator` object to find out whether *Trompete* (trumpet) is more closely related to *Posaune* (trombone) or to *Flöte* (flute):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "trompete = germanet.get_synsets_by_orthform(\"Trompete\").pop()\n",
     "flöte = germanet.get_synsets_by_orthform(\"Flöte\").pop()\n",
     "posaune = germanet.get_synsets_by_orthform(\"Posaune\").pop()\n",
-    "Klavier = germanet.get_synsets_by_orthform(\"Klavier\").pop()\n",
-    "Flügel_synsets = germanet.get_synsets_by_orthform(\"Flügel\")\n",
     "trompete_posaune = relatedness_calculator.simple_path(trompete, posaune)\n",
     "trompete_flöte = relatedness_calculator.simple_path(trompete, flöte)\n",
     "\n",
-    "print(\"Based on the simple path measure, is Trompete more similar to Posaune, than to Flöte? %s\" % str(trompete_posaune > trompete_flöte))\n",
+    "trompete_posaune > trompete_flöte "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Path based relatedness measures can also be used to disambiguate word senses. This example shows how to find the sense of *Flügel* (wing, blade, grand) which is most similar to *Klavier* (piano) according to three different path-based measures:. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Klavier = germanet.get_synsets_by_orthform(\"Klavier\").pop()\n",
+    "Flügel_synsets = germanet.get_synsets_by_orthform(\"Flügel\")\n",
+    "\n",
+    "results = []\n",
     "highest_sim_simple = 0.0\n",
     "highest_sim_leacock = 0.0\n",
     "highest_sim_wu = 0.0\n",
     "most_similar_synset = None\n",
+    "\n",
     "for synset in Flügel_synsets:\n",
     "    if synset.word_category == WordCategory.nomen:\n",
     "        sim_simple = relatedness_calculator.simple_path(synset, Klavier, normalize=True)\n",
     "        sim_leacock = relatedness_calculator.leacock_chodorow(synset, Klavier, normalize=True)\n",
     "        sim_wu = relatedness_calculator.wu_and_palmer(synset, Klavier, normalize=True)\n",
-    "        print(\"\\n These are the similarities between the synset for Klavier and %s : \\n Simple Path : %.2f\\n Leackock and Chodorow: %.2f\\n Wu and Palmer : %.2f\" % (str(synset), sim_simple, sim_leacock, sim_wu));\n",
+    "        results.append([synset.id, sim_simple, sim_leacock, sim_wu])\n",
+    "        \n",
     "        if sim_simple > highest_sim_simple and sim_leacock > highest_sim_leacock and sim_wu > highest_sim_wu :\n",
     "            highest_sim_simple = sim_simple\n",
     "            highest_sim_leacock = sim_leacock\n",
     "            highest_sim_wu = sim_wu\n",
     "            most_similar_synset = synset\n",
-    "print(\"\\nThe most similar synset out of all synsets corresponding to the word 'Flügel' is : %s\" %str(most_similar_synset))\n",
-    "print(most_similar_synset.lexunits[0].wiktionary_paraphrases)\n"
+    "\n",
+    "most_similar_synset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can verify that this is the most similar synset by looking at all the similarity results in a table:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.display import Markdown as md\n",
+    "\n",
+    "results_header = (\"| Synset | Simple Path | Leacock and Chodorow | Wu and Palmer |\\n\" +\n",
+    "                  \"|--------|-------------|----------------------|---------------|\\n\")\n",
+    "\n",
+    "results_table = results_header + \"\".join([\"|{}|{}|{}|{}|\\n\".format(*result) for result in results])\n",
+    "md(results_table)"
    ]
   },
   {

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -350,7 +350,7 @@
     "- path-based measures\n",
     "- information-content-based measures\n",
     "\n",
-    "Path-based measures compute the semantic relatedness between two concepts based on the shortest path between two synsets. The shortest path is the minimal number of nodes you have to walk from the source synset to the target synset. Different measures weigh or normalize the path-length in different ways."
+    "Path-based measures compute the semantic relatedness between two concepts based on the shortest path between two synsets in the hypernym relation. The shortest path length is the minimal number of nodes forming a path between the two synsets in the relation. Different measures weigh or normalize the path-length in different ways."
    ]
   },
   {
@@ -362,15 +362,10 @@
     }
    },
    "source": [
-    "At first we will look at the simple path distance between two synsets:\n",
+    "First we will look at the simple path distance between two synsets.\n",
     "\n",
     "Let's say you would like to know how *Fußball* and *Tennis* are related within \n",
-    "GermaNet. You first need to extract the synset for *Tennis*. Then you can check whether *Tennis* and *Fußball* share any \n",
-    "hypernyms and print them.\n",
-    "\n",
-    "Finally you can extract the shortest path between Fußball and Tennis, i.e. the minimal number of \n",
-    "nodes you have to walk from *Fußball* to end up at the synset of *Tennis*. You can also extract the distance between *Fußball* and \n",
-    "*Tennis* (in this case the path length). Synsets that are more similar will have a shorter distance than unrelated synsets.\n"
+    "GermaNet. You first need to extract the synset for *Tennis*. Then you can check whether *Tennis* and *Fußball* share any hypernyms."
    ]
   },
   {
@@ -386,11 +381,40 @@
    "outputs": [],
    "source": [
     "tennis_synsets = germanet.get_synsets_by_orthform(\"Tennis\")\n",
-    "print(tennis_synsets)\n",
     "tennis_synset = tennis_synsets[0]\n",
-    "print(fussball_synset.common_hypernyms(tennis_synset))\n",
-    "print(fussball_synset.shortest_path(tennis_synset))\n",
-    "print(\"Fußball and Tennis have a path distance of %d\" % fussball_synset.shortest_path_distance(tennis_synset))\n"
+    "fussball_synset.common_hypernyms(tennis_synset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can then extract the shortest path you can walk from *Fußball* to end up at *Tennis*. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fussball_synset.shortest_path(tennis_synset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also extract the distance between *Fußball* and *Tennis* (in this case the path length). Synsets that are more similar will have a shorter distance than unrelated synsets."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fussball_synset.shortest_path_distance(tennis_synset)"
    ]
   },
   {

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -559,6 +559,7 @@
    "outputs": [],
    "source": [
     "from germanetpy.icbased_similarity import ICBasedSimilarity\n",
+    "\n",
     "relatedness_nouns = ICBasedSimilarity(germanet=germanet, \n",
     "                                      wordcategory=WordCategory.nomen,\n",
     "                                      path=frequencylist_nouns)"
@@ -659,7 +660,7 @@
    "source": [
     "## Inspect Lexical Units\n",
     "Every synset contains one ore several Lexical Units. The list of Lexical Units (lexunit) can be accessed for any synset. Let's inspect the lexical units for *Fußball* 'football':\n",
-    "We have the lexunit *Fußballspiel* 'football match', the lexunit *Fußball* 'football' and the lexunit *Fußballsport* 'soccer ball'."
+    "We have the lexunit *Fußballspiel* 'football match', the lexunit *Fußball* 'football' and the lexunit *Fußballsport* 'soccer'."
    ]
   },
   {
@@ -963,7 +964,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For example, we can search for \"schießen\" but ignore upper or lowercasing in different orthforms:"
+    "For example, we can search for *schießen* 'shoot' but ignore upper or lowercasing in different orthforms:"
    ]
   },
   {
@@ -1004,7 +1005,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we now filter by word category and use only nouns, our result will be empty because there is not entry for 'schießen' as a noun:"
+    "If we now filter by word category and use only nouns, our result will be empty because there is no entry for 'schießen' as a noun:"
    ]
   },
   {

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -657,7 +657,7 @@
     }
    },
    "source": [
-    "### Inspect Lexical Units\n",
+    "## Inspect Lexical Units\n",
     "Every synset contains one ore several Lexical Units. The list of Lexical Units (lexunit) can be accessed for any synset. Let's inspect the lexical units for *Fußball* 'football':\n",
     "We have the lexunit *Fußballspiel* 'football match', the lexunit *Fußball* 'football' and the lexunit *Fußballsport* 'soccer ball'."
    ]
@@ -688,7 +688,7 @@
    "source": [
     "Every lexical unit has a number of orthographical forms. There are four different orthographical forms but not every \n",
     "lexical unit has an entry for all of them:\n",
-    "* main orth. form: \n",
+    "* main orth. form\n",
     "* orth. variation\n",
     "* old orth. form\n",
     "* old orth. variation\n",
@@ -710,12 +710,26 @@
    "outputs": [],
    "source": [
     "fussball_unit = germanet.get_lexunit_by_id(\"l29777\")\n",
-    "orth_forms = fussball_unit.get_all_orthforms()\n",
-    "print(orth_forms)\n",
+    "fussball_unit.get_all_orthforms()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "fussballclub_unit = germanet.get_lexunit_by_id(\"l32423\")\n",
-    "orth_forms = fussballclub_unit.get_all_orthforms()\n",
-    "print(orth_forms)\n",
-    "print(fussballclub_unit.orthvar)"
+    "fussballclub_unit.get_all_orthforms()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fussballclub_unit.orthvar"
    ]
   },
   {
@@ -727,7 +741,7 @@
     }
    },
    "source": [
-    "*Fußball* is a compound, which are very frequent in the German language. GermaNet stores information about the \n",
+    "*Fußball* is a compound noun, which are very frequent in the German language. GermaNet stores information about the \n",
     "compound, for example that *Fuß* 'foot' is the modifier and *ball* 'ball' is the head.\n"
    ]
   },
@@ -743,7 +757,7 @@
    },
    "outputs": [],
    "source": [
-    "print(fussball_unit.compound_info)\n"
+    "fussball_unit.compound_info"
    ]
   },
   {
@@ -756,14 +770,25 @@
    },
    "source": [
     "Lexical units are related to other lexical units by different lexical relations. The most common and most general \n",
-    "lexical relation is synonymy, but there are other relations annotated as well. For example, for some compounds there has been work\n",
-    "on annotating the relation between the compound and the modifier. In this example the compound *Fußball* has the manner \n",
-    "functioning of *Fuß*. \n",
-    "\n",
-    "The relations can be unidirectional (e.g. the relation \"has manner of functioning\" goes from *Fußball*\n",
-    "to *Fuß*, but not the other way around. The relation can also be bidirectional, e.g. *Fußball* and *Fußballspiel* are \n",
-    "synonyms of each other. If you are interested in finding out which unidirectional relations point towards *Fußball*, these\n",
-    "can be accessed via \"incoming_relations\":\n"
+    "lexical relation is synonymy (i.e., the relation which groups lexical units into synsets), but there are other lexical relations in GermaNet as well. For example, for some compounds there has been work\n",
+    "on annotating the relation between the compound and the modifier. In this example the compound *Fußball* has the manner of functioning *Fuß*. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fussball_unit.relations"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The relations can be unidirectional (e.g., the relation \"has manner of functioning\" goes from *Fußball*\n",
+    "to *Fuß*, but not the other way around). The relations can also be bidirectional (e.g., *Fußball* and *Fußballspiel* are synonyms of each other). If you are interested in finding out which unidirectional relations point towards *Fußball*, these can be accessed via \"incoming_relations\":"
    ]
   },
   {
@@ -778,8 +803,7 @@
    },
    "outputs": [],
    "source": [
-    "print(fussball_unit.relations)\n",
-    "print(fussball_unit.incoming_relations)\n"
+    "fussball_unit.incoming_relations"
    ]
   },
   {
@@ -791,7 +815,7 @@
     }
    },
    "source": [
-    "Some lexical units have sense definitions, harvested from the German Wictionary. These can be accessed with the wiktionary_paraphrases field."
+    "Some lexical units have sense definitions, harvested from the German Wictionary. These can be accessed with the `wiktionary_paraphrases` field."
    ]
   },
   {
@@ -806,7 +830,7 @@
    },
    "outputs": [],
    "source": [
-    "print(fussball_unit.wiktionary_paraphrases)"
+    "fussball_unit.wiktionary_paraphrases"
    ]
   },
   {
@@ -818,7 +842,7 @@
     }
    },
    "source": [
-    "Some lexical units have also been linked to the English WordNet. The can be accessed with the ili_records field. "
+    "Some lexical units have also been linked to the English WordNet. The can be accessed with the `ili_records` field. "
    ]
   },
   {
@@ -833,7 +857,7 @@
    },
    "outputs": [],
    "source": [
-    "print(fussball_unit.ili_records)\n"
+    "fussball_unit.ili_records"
    ]
   },
   {
@@ -846,9 +870,7 @@
    },
    "source": [
     "Lexical units which are verbs provide information on language use by giving at least one example sentence.\n",
-    "They are also annotated with subcategorisation patterns / verb complementations (frames). It is possible to extract\n",
-    "verbs with specific complements of interest, for example if you're interested in all verbs that allow accusative complements\n",
-    "you can extract them with specific methods, defined in the frames class. \n"
+    "They are also annotated with subcategorisation patterns / verb complementations (frames).\n"
    ]
   },
   {
@@ -864,13 +886,62 @@
    "outputs": [],
    "source": [
     "schiessen = germanet.get_lexunit_by_id(\"l80272\")\n",
-    "print(schiessen)\n",
-    "print(schiessen.examples)\n",
-    "print(schiessen.frames)\n",
+    "schiessen"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schiessen.examples"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "schiessen.frames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is possible to extract verbs with specific complements of interest. For example, if you're interested in all verbs that allow accusative complements, you can extract them with specific methods, defined in the `Frames` class. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "f = Frames(germanet.frames2lexunits)\n",
-    "all_verbs_with_accusative_complement = f.extract_accusative_complemtent()\n",
-    "print(\"There are  %d verbs that can take an accusative complement in GermaNet \\n An example of such is: %s \\n Another example is : %s\"\n",
-    "      % (len(all_verbs_with_accusative_complement), all_verbs_with_accusative_complement.pop(), all_verbs_with_accusative_complement.pop()))\n"
+    "all_verbs_with_accusative_complement = f.extract_accusative_complement()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# How many verbs take accusative complements?\n",
+    "len(all_verbs_with_accusative_complement)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What are some examples?\n",
+    "(all_verbs_with_accusative_complement.pop(), all_verbs_with_accusative_complement.pop())"
    ]
   },
   {

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -55,11 +55,11 @@
    },
    "outputs": [],
    "source": [
-    "data_path = str(Path.home()) + \"/germanet_data\"\n",
-    "frequencylist_nouns = data_path + \"/noun_freqs_decow14_16.txt\"\n",
     "from pathlib import Path\n",
     "from germanetpy.germanet import Germanet\n",
     "\n",
+    "data_path = str(Path.home()) + \"/data/germanet/GN_V150/GN_V150_XML\"\n",
+    "frequencylist_nouns = str(Path.home()) + \"/data/germanet/GN_V150/FreqLists/noun_freqs_decow14_16.txt\"\n",
     "germanet = Germanet(data_path)"
    ]
   },
@@ -491,7 +491,13 @@
     "        sim_simple = relatedness_calculator.simple_path(synset, Klavier, normalize=True)\n",
     "        sim_leacock = relatedness_calculator.leacock_chodorow(synset, Klavier, normalize=True)\n",
     "        sim_wu = relatedness_calculator.wu_and_palmer(synset, Klavier, normalize=True)\n",
-    "        results.append([synset.id, sim_simple, sim_leacock, sim_wu])\n",
+    "        results.append([\n",
+    "            synset.id, \n",
+    "            \", \".join(lu.orthform for lu in synset.lexunits),\n",
+    "            sim_simple, \n",
+    "            sim_leacock, \n",
+    "            sim_wu\n",
+    "        ])\n",
     "        \n",
     "        if sim_simple > highest_sim_simple and sim_leacock > highest_sim_leacock and sim_wu > highest_sim_wu :\n",
     "            highest_sim_simple = sim_simple\n",
@@ -517,10 +523,10 @@
    "source": [
     "from IPython.display import Markdown as md\n",
     "\n",
-    "results_header = (\"| Synset | Simple Path | Leacock and Chodorow | Wu and Palmer |\\n\" +\n",
-    "                  \"|--------|-------------|----------------------|---------------|\\n\")\n",
+    "results_header = (\"| Synset ID | Lex Units | Simple Path | Leacock and Chodorow | Wu and Palmer |\\n\" +\n",
+    "                  \"|-----------|-----------|-------------|----------------------|---------------|\\n\")\n",
     "\n",
-    "results_table = results_header + \"\".join([\"|{}|{}|{}|{}|\\n\".format(*result) for result in results])\n",
+    "results_table = results_header + \"\".join([\"|{}|{}|{}|{}|{}|\\n\".format(*result) for result in results])\n",
     "md(results_table)"
    ]
   },

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -532,7 +532,7 @@
     "\n",
     "One problem with path-based measures is that paths of the same length in the hypernym relation can correspond to very different intuitive semantic \"distances\".\n",
     "Measures based on *information content* (IC) seek to solve this problem by augmenting information about the structural distances in the hypernym relation with information about word frequencies. \n",
-    "The word frequencies are used to compute the information content, which grades concepts from more specific to more general. If a very specific synset is compared to a very general one, the relatedness will be low. The relatedness of two synsets measured based on the information content of their least common subsumer (the lowest synset in the hierarchy that is hypernym to both synsets).\n",
+    "The word frequencies are used to compute the information content, which grades concepts from more specific to more general. If a very specific synset is compared to a very general one, the relatedness will be low. The relatedness of two synsets is measured based on the information content of their least common subsumer (the lowest synset in the hierarchy that is hypernym to both synsets).\n",
     "\n",
     "To use these measures, you have to create an `ICBasedSimilarity` object that takes frequency lists as an additional argument. These lists contain the raw frequencies of the nouns, adjectives and verbs that are in Germanet, based on a very large corpus. You can use either the provided frequency lists or your own lists."
    ]

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -40,7 +40,9 @@
     "pycharm": {}
    },
    "source": [
-    "Whenever you want to use the API, the first thing you would do is to create a GermaNet object as this loads the data and provides access to it. The data (all XML files) have to be stored in one directory which has to be specified as the first argument when you construct the GermaNet object. If you want to run this code, put your XML files in a \"germanet_data\" directory in your home directory or change the path to the location on your computer. The API also provides methods to compute semantic similarity / relatedness between words (Synsets). To be able to use all of them you have to provide frequency lists for each word category. These lists can be downloaded from: <!-- where? -->"
+    "Whenever you want to use the API, the first thing you do is to create a `Germanet` object, which loads the data and provides access to it. The data (all XML files) have to be stored in one directory, whose path has to be specified as the first argument when you construct the GermaNet object. \n",
+    "\n",
+    "If you want to run this code, put your XML files in a \"germanet_data\" directory in your home directory or change the path to the location on your computer. The API also provides methods to compute semantic similarity / relatedness between words (Synsets). To be able to use all of them you have to provide frequency lists for each word category. These lists can be downloaded from: <!-- where? -->"
    ]
   },
   {

--- a/pythonAPI/germanetpy_tutorial.ipynb
+++ b/pythonAPI/germanetpy_tutorial.ipynb
@@ -95,9 +95,7 @@
     }
    },
    "source": [
-    "## How to inspect information for a single word input\n",
-    "\n",
-    "### Inspect synsets\n",
+    "## How to inspect synset information for a single word input\n",
     "\n",
     "Let's consider the input word *Fußball* 'football'. The following shows how to extract all synsets given an input word. Many words are ambiguous; *Fußball* belongs to two synsets. "
    ]
@@ -345,7 +343,8 @@
     "pycharm": {}
    },
    "source": [
-    "# Use the semantic utils to measure semantic similarity / relatedness\n",
+    "## Use the semantic utils to measure semantic similarity / relatedness\n",
+    "\n",
     "You can also use the API to compare a synset with another synset. These methods work only for two synsets that have the same word category, for example for two nouns. There are two different types of similarity measures:\n",
     "- path-based measures\n",
     "- information-content-based measures\n",
@@ -425,7 +424,7 @@
     }
    },
    "source": [
-    "## Example for path-based measures\n",
+    "### Example for path-based measures\n",
     "\n",
     "The following example shows how to use path-based semantic relatedness measures to check whether *Trompete* (trumpet) is more closely related to *Posaune* (trombone) than to *Flöte* (flute) and how to disambiguate *Flügel* (wing, blade, grand) in the context of *Klavier* (piano). \n",
     "\n",
@@ -544,7 +543,7 @@
     "pycharm": {}
    },
    "source": [
-    "## Example for IC-based measures\n",
+    "### Example for IC-based measures\n",
     "\n",
     "One problem with path-based measures is that paths of the same length in the hypernym relation can correspond to very different intuitive semantic \"distances\".\n",
     "Measures based on *information content* (IC) seek to solve this problem by augmenting information about the structural distances in the hypernym relation with information about word frequencies. \n",


### PR DESCRIPTION
This continues the series of changes in #3 , breaking up examples, removing print(), doing some rewording. 